### PR TITLE
Use postgis 11-3.3 instead of 15-3.3 to mimic PROD & ACC environments

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,7 +27,7 @@ services:
     command: /run.sh
 
   postgis:
-    image: postgis/postgis:15-3.3
+    image: postgis/postgis:11-3.3
     ports:
       - "54321:5432"
     environment:


### PR DESCRIPTION
## Description

Because on Azure postgres 11 is used we want to mimic this in the application, therefore we now use the postgis:11-3.3 image.
When Azure has been migrated the applicaiton will also be updated to the correct version of postgis.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines

