### PR TITLE
Raise `ObjectDoesNotExist` or `MultipleObjectsReturned` when 0 or more items where retrieved from GISIB in the get_collection function

### DIFF
--- a/app/signals_gisib/gisib/update_epr_curative.py
+++ b/app/signals_gisib/gisib/update_epr_curative.py
@@ -1,5 +1,6 @@
 from typing import Tuple
 
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.utils import timezone
 
 from signals_gisib.gisib.api import get_collection
@@ -12,7 +13,11 @@ def update_epr_curative(epr_curative: EPRCurative) -> Tuple[EPRCurative, bool]:
     """
 
     updated = False
-    epr_curative_json = get_collection('EPR Curatief', epr_curative.gisib_id)
+
+    try:
+        epr_curative_json = get_collection('EPR Curatief', epr_curative.gisib_id)
+    except (ObjectDoesNotExist, MultipleObjectsReturned):
+        return epr_curative, updated
 
     try:
         collection_item = CollectionItem.objects.get(gisib_id=epr_curative.gisib_id,

--- a/app/signals_gisib/tests/gisib/cassettes/test_get_collection_raises_multiple_objects_returned.yaml
+++ b/app/signals_gisib/tests/gisib/cassettes/test_get_collection_raises_multiple_objects_returned.yaml
@@ -1,0 +1,205 @@
+interactions:
+- request:
+    body: '{"Username": "test-user", "Password": "test-password", "ApiKey": "test-api-key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://amsterdam-test.gisib.nl/api/api/Login
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/IvLr78wn
+        n0+LL4vvVLNvv7r6sji4nN2b3Xu+nP7g+eLh9U9dH1x/8fT43fMfHO88vzdvJ5+/+kH23Wk7+S59
+        9/pFNfnus59+/nu/qH6fN2e7L4qz5mz56v705OzTs7er3/snT77zcEwd/OR07yevJ4tn7U+9pi8W
+        z66y3/vF6vd5TY3f0u/fbcscn//0dO+LN1/svPjBk59+8fRZ8cVP/8T9Lz7/TvH7LH6q/GLv97n6
+        4rs/Of/i6Wzx4vPfZ++suCp+6veeX539dPXuxU9Pd168Of3Bi6fT3ecn31lN732BwSy5j4IQWM/q
+        8l77k68+/+6Xu9nL0xcX+/f3P33z9ovTne3z7YO3k+8uX//kqyfbv8/vXzf/D0R86CwNAQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' data: https:;'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2023 09:58:37 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer 1234567890
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://amsterdam-test.gisib.nl/api/api/Collections/Boom/Items/1879642
+  response:
+    body:
+      string: '{"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::28992"}},"links":[{"rel":"next","type":"application/geo+json","title":"Next
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/Boom/items?crs=28992&limit=1&offset=1"},{"rel":"prev","type":"application/geo+json","title":"Previous
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/Boom/items?crs=28992&limit=1&offset=0"},{"rel":"first","type":"application/geo+json","title":"First
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/Boom/items?crs=28992&limit=1&offset=0"}],"features":[{"type":"Feature","geometry":{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:28992"}},"coordinates":[127506.08,480104.53]},"properties":{"Actueel
+        kwaliteitsniveau":null,"Afvoeren":null,"Beheerder":{"Id":798,"GUID":"{7035C783-3270-4953-ABA3-BB3195CCAA36}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheerder/items/798","Description":"Gemeente"},"Beheerder
+        gedetailleerd":{"Id":20125,"GUID":"{56AFC50D-CB0B-46F5-A0BC-3C92BDB47743}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheerder
+        gedetailleerd/items/20125","Description":"Stadsdeel Zuidoost"},"Beheergebied":{"Id":26976,"GUID":"{F8110411-9910-4FF0-9231-E12BE9DFD38D}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheergebied/items/26976","Description":"Gaasperdam,
+        Driemond"},"Beleidsstatus":null,"Beoogde omlooptijd":null,"Bereikbaarheid":null,"Beschermde
+        flora en fauna":null,"Beschermingsstatus":null,"Beschermingsstatus gedetailleerd":null,"BGT
+        Bronhouder":null,"BGT Eindregistratie":null,"BGT In onderzoek":null,"BGT Objecttype":null,"BGT
+        Opmerking":null,"BGT Status":null,"Boombeeld":null,"Boomgroep":null,"Boomhoogte
+        actueel":null,"Boomhoogteklasse eindbeeld":null,"Boomveiligheidsklasse":null,"Eigenaar":{"Id":1374,"GUID":"{C6062476-5FF6-43DB-951F-3F94D450CB6F}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Eigenaar/items/1374","Description":"Gemeente"},"Eigenaar
+        gedetailleerd":{"Id":20142,"GUID":"{64B2F3AA-7D6E-477B-9984-880CB1A8A01C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Eigenaar
+        gedetailleerd/items/20142","Description":"Gemeente Amsterdam"},"Gebiedstype":null,"Gebruiksfunctie":null,"Gemeente":{"Id":20247,"GUID":"{31C33111-C0B4-489E-8539-1B7D74DF2E5A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Gemeente/items/20247","Description":"Amsterdam"},"Gewenst
+        kwaliteitsniveau":{"Id":1875,"GUID":"{5A4DF2E9-813A-4750-BAA0-6906C07D12E6}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Gewenst
+        kwaliteitsniveau/items/1875","Description":"C"},"Groeifase":null,"Grondsoort":null,"Grondsoort
+        gedetailleerd":null,"Herplantplicht":null,"ID uit oude beheerindeling":"7BAA8D12-2C69-421C-9252-AF5605657D85","Identificatie":null,"Jaar
+        van aanleg":2005,"Kiemjaar":null,"Kroondiameterklasse actueel":null,"Kroondiameterklasse
+        eindbeeld":null,"Kroonvolume":null,"Kweker":null,"Leeftijd":null,"Leverancier":null,"Ligging":null,"LV
+        publicatiedatum":null,"Meerstammig":null,"Memo":"Boom niet aanwezig","Monetaire
+        boomwaarde":null,"MSLINK":null,"Objecttype":{"Id":14109,"GUID":"{635136A6-334C-4C9A-B0AD-F69C0CDB52B7}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Objecttype/items/14109","Description":"Boom"},"Omgevingsrisicoklasse":{"Id":1911,"GUID":"{3DED9455-E00B-4050-92AD-C2E59F83AD36}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Omgevingsrisicoklasse/items/1911","Description":"Hoog"},"Onderhoudsplichtige":null,"Openbare
+        ruimte":null,"Opleverdatum":null,"Relatieve hoogteligging":null,"Snoeifase":null,"Soortnaam":{"Id":36335,"GUID":"{4BBB3FB3-17E0-438F-9AA6-23DA0C88AD85}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Soortnaam/items/36335","Description":"Quercus
+        palustris"},"Stamdiameter":null,"Stamdiameterklasse":null,"Standplaats":{"Id":152,"GUID":"{858EB57E-40A8-4A05-A12F-058F85156DBE}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Standplaats/items/152","Description":"Gras-
+        en kruidachtigen"},"Standplaats gedetailleerd":{"Id":826,"GUID":"{DEB1BB8B-1683-4FEC-89EA-42FA6F87FC6F}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Standplaats
+        gedetailleerd/items/826","Description":"Gazon"},"Takvrije ruimte tot gebouw
+        (eindbeeld)":null,"Takvrije stam eindbeeld":null,"Takvrije zone primair eindbeeld":null,"Takvrije
+        zone secundair eindbeeld":null,"Theoretisch eindjaar":null,"Tijdstip registratie":null,"Transponder":null,"Type":null,"Type
+        gedetailleerd":null,"Vermeerderingsvorm":null,"Verplant":null,"Verplantbaar":null,"Verwijderdatum":null,"Vrije
+        doorrijhoogte":null,"Vrije doorrijhoogte primair":null,"Vrije doorrijhoogte
+        secundair":null,"Vrije takval":null,"Waterschap":null,"Wijk":{"Id":20366,"GUID":"{F4C68F4A-EAC5-4C8F-B596-4FF4F867DE4E}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Wijk/items/20366","Description":"Nellestein"},"Wijze
+        van inwinning":null,"Woonplaats":{"Id":20249,"GUID":"{02CC5815-955D-4B4B-BB76-3E0E3B45280C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Woonplaats/items/20249","Description":"Amsterdam"},"Objectnummer":null,"Controlefrequentie":null,"ConversieID":null,"X
+        Coordinaat":127506.08,"Y Coordinaat":480104.53,"Straatnaam oude beheergegevens":null,"BGT
+        Type":null,"IMGeo Plustype":null,"Conditiescore":null,"Actuele opkroonhoogte":null,"Beoogde
+        opkroonhoogte":null,"IMGeo Plusstatus":null,"Postcode":null,"Stadsdeel of
+        kern":{"Id":20268,"GUID":"{B52292B5-6FA0-427B-B4B8-BFFFBA08904B}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Stadsdeel
+        of kern/items/20268","Description":"Zuidoost"},"Datum inwinning":null,"Knipoppervlakte":null,"Groeiplaatsinrichting":null,"Boombeschermer":null,"BOR
+        Type":null,"Objectnaam":null,"Snoeifrequentie":null,"Knipfrequentie":null,"Beheerafspraak":{"Id":1284591,"GUID":"{CE456BFB-1EE5-4CF0-B4B9-61DF2809521C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheerafspraak/items/1284591","Description":"Boom
+        - BOOM IN GRAS"},"Buurt":{"Id":20565,"GUID":"{60ABA146-F6FE-4AA9-B3D6-C1A76D42DD4A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Buurt/items/20565","Description":"L-buurt"},"Aangemaakt
+        door":null,"Boomhoogteklasse actueel":null,"Aantal":1.0,"Deelsportcomplex":null,"Inwinningsbedrijf":null,"Sportterrein":null,"Sportveld":null,"BoomID
+        Geovisia":"603442","BoomID Gisib":"603442","Foto":null,"Beleid opmerkingen":null,"Datum
+        laatste snoei":null,"Datum volgende inspectie":null,"Boomaantasting":null,"Selectie
+        1":null,"Selectie 2":null,"Selectie uitvoering":null,"Selectie kap en aanplanting":null,"Snoeiwijze":null,"Boombeheerbaarheid":null,"Controlefrequentie
+        BVC":{"Id":1846305,"GUID":"{741EA039-BB44-471F-89FF-A22997B46852}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Controlefrequentie
+        BVC/items/1846305","Description":"Geen"},"Boomgrootte":null,"Toekomstverwachting":null,"Soortnaam
+        Nederlands":{"Id":33657,"GUID":"{0F873361-D5A7-4CA1-A8A6-33B48D4F9C7D}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Soortnaam
+        Nederlands/items/33657","Description":"Moeraseik"},"Boomconditie":null,"Matching":"Alleen
+        geofysia","Controle positie boompunt":{"Id":1883450,"GUID":"{23F197B9-AE83-482F-8150-AC1D13A5F1CA}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Controle
+        positie boompunt/items/1883450","Description":"Boom niet aanwezig"},"Latitude":52.308218,"Longitude":4.984062,"URL
+        Google Maps":"https://www.google.com/maps/search/?api=1&query=52.308218,4.984062","URL
+        Google Maps 2":"https://www.google.com/maps/dir/?api=1&destination=52.308218,4.984062&travelmode=","Ecologisch
+        beheren":null,"Restrictie beschermde soort EPR":null,"Dichtstbijzijnde BAG
+        Adres":"Liendenhof 141","Dichtstbijzijnde BAG Postcode":"1108HH","Afstand
+        tot dichtstbijzijnde BAG Adres":33.1,"Code":null,"GUID":"{57F9DB47-BB54-4E41-9116-3CF4342F7F70}","Id":1879642,"Description":null,"IMGeoId":null,"Valid_Till":null,"LastUpdate":"2022-01-07T12:40:33.639622","Revisie":1}},
+        {"type":"Feature","geometry":{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:28992"}},"coordinates":[127506.08,480104.53]},"properties":{"Actueel
+        kwaliteitsniveau":null,"Afvoeren":null,"Beheerder":{"Id":798,"GUID":"{7035C783-3270-4953-ABA3-BB3195CCAA36}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheerder/items/798","Description":"Gemeente"},"Beheerder
+        gedetailleerd":{"Id":20125,"GUID":"{56AFC50D-CB0B-46F5-A0BC-3C92BDB47743}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheerder
+        gedetailleerd/items/20125","Description":"Stadsdeel Zuidoost"},"Beheergebied":{"Id":26976,"GUID":"{F8110411-9910-4FF0-9231-E12BE9DFD38D}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheergebied/items/26976","Description":"Gaasperdam,
+        Driemond"},"Beleidsstatus":null,"Beoogde omlooptijd":null,"Bereikbaarheid":null,"Beschermde
+        flora en fauna":null,"Beschermingsstatus":null,"Beschermingsstatus gedetailleerd":null,"BGT
+        Bronhouder":null,"BGT Eindregistratie":null,"BGT In onderzoek":null,"BGT Objecttype":null,"BGT
+        Opmerking":null,"BGT Status":null,"Boombeeld":null,"Boomgroep":null,"Boomhoogte
+        actueel":null,"Boomhoogteklasse eindbeeld":null,"Boomveiligheidsklasse":null,"Eigenaar":{"Id":1374,"GUID":"{C6062476-5FF6-43DB-951F-3F94D450CB6F}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Eigenaar/items/1374","Description":"Gemeente"},"Eigenaar
+        gedetailleerd":{"Id":20142,"GUID":"{64B2F3AA-7D6E-477B-9984-880CB1A8A01C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Eigenaar
+        gedetailleerd/items/20142","Description":"Gemeente Amsterdam"},"Gebiedstype":null,"Gebruiksfunctie":null,"Gemeente":{"Id":20247,"GUID":"{31C33111-C0B4-489E-8539-1B7D74DF2E5A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Gemeente/items/20247","Description":"Amsterdam"},"Gewenst
+        kwaliteitsniveau":{"Id":1875,"GUID":"{5A4DF2E9-813A-4750-BAA0-6906C07D12E6}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Gewenst
+        kwaliteitsniveau/items/1875","Description":"C"},"Groeifase":null,"Grondsoort":null,"Grondsoort
+        gedetailleerd":null,"Herplantplicht":null,"ID uit oude beheerindeling":"7BAA8D12-2C69-421C-9252-AF5605657D85","Identificatie":null,"Jaar
+        van aanleg":2005,"Kiemjaar":null,"Kroondiameterklasse actueel":null,"Kroondiameterklasse
+        eindbeeld":null,"Kroonvolume":null,"Kweker":null,"Leeftijd":null,"Leverancier":null,"Ligging":null,"LV
+        publicatiedatum":null,"Meerstammig":null,"Memo":"Boom niet aanwezig","Monetaire
+        boomwaarde":null,"MSLINK":null,"Objecttype":{"Id":14109,"GUID":"{635136A6-334C-4C9A-B0AD-F69C0CDB52B7}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Objecttype/items/14109","Description":"Boom"},"Omgevingsrisicoklasse":{"Id":1911,"GUID":"{3DED9455-E00B-4050-92AD-C2E59F83AD36}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Omgevingsrisicoklasse/items/1911","Description":"Hoog"},"Onderhoudsplichtige":null,"Openbare
+        ruimte":null,"Opleverdatum":null,"Relatieve hoogteligging":null,"Snoeifase":null,"Soortnaam":{"Id":36335,"GUID":"{4BBB3FB3-17E0-438F-9AA6-23DA0C88AD85}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Soortnaam/items/36335","Description":"Quercus
+        palustris"},"Stamdiameter":null,"Stamdiameterklasse":null,"Standplaats":{"Id":152,"GUID":"{858EB57E-40A8-4A05-A12F-058F85156DBE}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Standplaats/items/152","Description":"Gras-
+        en kruidachtigen"},"Standplaats gedetailleerd":{"Id":826,"GUID":"{DEB1BB8B-1683-4FEC-89EA-42FA6F87FC6F}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Standplaats
+        gedetailleerd/items/826","Description":"Gazon"},"Takvrije ruimte tot gebouw
+        (eindbeeld)":null,"Takvrije stam eindbeeld":null,"Takvrije zone primair eindbeeld":null,"Takvrije
+        zone secundair eindbeeld":null,"Theoretisch eindjaar":null,"Tijdstip registratie":null,"Transponder":null,"Type":null,"Type
+        gedetailleerd":null,"Vermeerderingsvorm":null,"Verplant":null,"Verplantbaar":null,"Verwijderdatum":null,"Vrije
+        doorrijhoogte":null,"Vrije doorrijhoogte primair":null,"Vrije doorrijhoogte
+        secundair":null,"Vrije takval":null,"Waterschap":null,"Wijk":{"Id":20366,"GUID":"{F4C68F4A-EAC5-4C8F-B596-4FF4F867DE4E}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Wijk/items/20366","Description":"Nellestein"},"Wijze
+        van inwinning":null,"Woonplaats":{"Id":20249,"GUID":"{02CC5815-955D-4B4B-BB76-3E0E3B45280C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Woonplaats/items/20249","Description":"Amsterdam"},"Objectnummer":null,"Controlefrequentie":null,"ConversieID":null,"X
+        Coordinaat":127506.08,"Y Coordinaat":480104.53,"Straatnaam oude beheergegevens":null,"BGT
+        Type":null,"IMGeo Plustype":null,"Conditiescore":null,"Actuele opkroonhoogte":null,"Beoogde
+        opkroonhoogte":null,"IMGeo Plusstatus":null,"Postcode":null,"Stadsdeel of
+        kern":{"Id":20268,"GUID":"{B52292B5-6FA0-427B-B4B8-BFFFBA08904B}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Stadsdeel
+        of kern/items/20268","Description":"Zuidoost"},"Datum inwinning":null,"Knipoppervlakte":null,"Groeiplaatsinrichting":null,"Boombeschermer":null,"BOR
+        Type":null,"Objectnaam":null,"Snoeifrequentie":null,"Knipfrequentie":null,"Beheerafspraak":{"Id":1284591,"GUID":"{CE456BFB-1EE5-4CF0-B4B9-61DF2809521C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheerafspraak/items/1284591","Description":"Boom
+        - BOOM IN GRAS"},"Buurt":{"Id":20565,"GUID":"{60ABA146-F6FE-4AA9-B3D6-C1A76D42DD4A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Buurt/items/20565","Description":"L-buurt"},"Aangemaakt
+        door":null,"Boomhoogteklasse actueel":null,"Aantal":1.0,"Deelsportcomplex":null,"Inwinningsbedrijf":null,"Sportterrein":null,"Sportveld":null,"BoomID
+        Geovisia":"603442","BoomID Gisib":"603442","Foto":null,"Beleid opmerkingen":null,"Datum
+        laatste snoei":null,"Datum volgende inspectie":null,"Boomaantasting":null,"Selectie
+        1":null,"Selectie 2":null,"Selectie uitvoering":null,"Selectie kap en aanplanting":null,"Snoeiwijze":null,"Boombeheerbaarheid":null,"Controlefrequentie
+        BVC":{"Id":1846305,"GUID":"{741EA039-BB44-471F-89FF-A22997B46852}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Controlefrequentie
+        BVC/items/1846305","Description":"Geen"},"Boomgrootte":null,"Toekomstverwachting":null,"Soortnaam
+        Nederlands":{"Id":33657,"GUID":"{0F873361-D5A7-4CA1-A8A6-33B48D4F9C7D}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Soortnaam
+        Nederlands/items/33657","Description":"Moeraseik"},"Boomconditie":null,"Matching":"Alleen
+        geofysia","Controle positie boompunt":{"Id":1883450,"GUID":"{23F197B9-AE83-482F-8150-AC1D13A5F1CA}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Controle
+        positie boompunt/items/1883450","Description":"Boom niet aanwezig"},"Latitude":52.308218,"Longitude":4.984062,"URL
+        Google Maps":"https://www.google.com/maps/search/?api=1&query=52.308218,4.984062","URL
+        Google Maps 2":"https://www.google.com/maps/dir/?api=1&destination=52.308218,4.984062&travelmode=","Ecologisch
+        beheren":null,"Restrictie beschermde soort EPR":null,"Dichtstbijzijnde BAG
+        Adres":"Liendenhof 141","Dichtstbijzijnde BAG Postcode":"1108HH","Afstand
+        tot dichtstbijzijnde BAG Adres":33.1,"Code":null,"GUID":"{57F9DB47-BB54-4E41-9116-3CF4342F7F70}","Id":1879642,"Description":null,"IMGeoId":null,"Valid_Till":null,"LastUpdate":"2022-01-07T12:40:33.639622","Revisie":1}}]}'
+    headers:
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' data: https:;'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2023 09:58:39 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/app/signals_gisib/tests/gisib/cassettes/test_get_collection_raises_object_does_not_exist.yaml
+++ b/app/signals_gisib/tests/gisib/cassettes/test_get_collection_raises_object_does_not_exist.yaml
@@ -1,0 +1,106 @@
+interactions:
+- request:
+    body: '{"Username": "test-user", "Password": "test-password", "ApiKey": "test-api-key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://amsterdam-test.gisib.nl/api/api/Login
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/IvLr78wn
+        n0+LL4vvVLNvv7r6sji4nN2b3Xu+nP7g+eLh9U9dH1x/8fT43fMfHO88vzdvJ5+/+kH23Wk7+S59
+        9/pFNfnus59+/nu/qH6fN2e7L4qz5mz56v705OzTs7er3/snT77zcEwd/OR07yevJ4tn7U+9pi8W
+        z66y3/vF6vd5TY3f0u/fbcscn//0dO+LN1/svPjBk59+8fRZ8cVP/8T9Lz7/TvH7LH6q/GLv97n6
+        4rs/Of/i6Wzx4vPfZ++suCp+6veeX539dPXuxU9Pd168Of3Bi6fT3ecn31lN732BwSy5j4IQWM/q
+        8l77k68+/+6Xu9nL0xcX+/f3P33z9ovTne3z7YO3k+8uX//kqyfbv8/vXzf/D0R86CwNAQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' data: https:;'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2023 09:58:37 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer 1234567890
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://amsterdam-test.gisib.nl/api/api/Collections/Boom/Items/1879642
+  response:
+    body:
+      string: '{"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::28992"}},"links":[{"rel":"next","type":"application/geo+json","title":"Next
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/Boom/items?crs=28992&limit=1&offset=1"},{"rel":"prev","type":"application/geo+json","title":"Previous
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/Boom/items?crs=28992&limit=1&offset=0"},{"rel":"first","type":"application/geo+json","title":"First
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/Boom/items?crs=28992&limit=1&offset=0"}],"features":[]}'
+    headers:
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' data: https:;'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 31 Jan 2023 09:58:39 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/app/signals_gisib/tests/gisib/cassettes/test_update_epr_curative_collection_item_does_not_exist.yaml
+++ b/app/signals_gisib/tests/gisib/cassettes/test_update_epr_curative_collection_item_does_not_exist.yaml
@@ -1,0 +1,109 @@
+interactions:
+- request:
+    body: '{"Username": "test-user", "Password": "test-password", "ApiKey": "test-api-key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://amsterdam-test.gisib.nl/api/api/Login
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/IvLr78wn
+        n0+LL4vvVLNvv7r6sji4nN2b3Xu+nP7g+eLh9U9dH1x/8fT43fMfHO88vzdvJ5+/+kH23Wk7+S59
+        9/pFNfnus59+/nu/qH6fN2e7L4qz5mz56v705OzTs7er3/snT77zcEwd/OR07yevJ4tn7U+9pi8W
+        z66y3/vF6vd5TY3f0u/fbcscn//0dO+LN1/svPjBk59+8fRZ8cVP/8T9Lz7/TvH7LH6q/GLv97n6
+        4rs/Of/i6Wzx4vPfZ++suCp+6veeX539dPXuxU9Pd168me59+eaL3ecn31lN732BwSy5j4IQmJy1
+        xcPpL/qJ3+v3uvcTv/f98mHxi45/n/u/98H+T158+tXp8fEPnjw7rg5++ru//9Pv/MT/Awh1g+8N
+        AQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' blob: data: https:;img-src
+        ''self'' https: data: blob:;'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Wed, 01 Mar 2023 14:25:17 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer 1234567890
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://amsterdam-test.gisib.nl/api/api/Collections/EPR%20Curatief/Items/3751039
+  response:
+    body:
+      string: '{"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::28992"}},"links":[{"rel":"next","type":"application/geo+json","title":"Next
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/EPR Curatief/items?crs=28992&limit=1&offset=1"},{"rel":"prev","type":"application/geo+json","title":"Previous
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/EPR Curatief/items?crs=28992&limit=1&offset=0"},{"rel":"first","type":"application/geo+json","title":"First
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/EPR Curatief/items?crs=28992&limit=1&offset=0"}],"features":[]}'
+    headers:
+      Content-Length:
+      - '4574'
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' blob: data: https:;img-src
+        ''self'' https: data: blob:;'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 01 Mar 2023 14:25:17 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/app/signals_gisib/tests/gisib/cassettes/test_update_epr_curative_collection_item_multiple_objects_returned.yaml
+++ b/app/signals_gisib/tests/gisib/cassettes/test_update_epr_curative_collection_item_multiple_objects_returned.yaml
@@ -1,0 +1,154 @@
+interactions:
+- request:
+    body: '{"Username": "test-user", "Password": "test-password", "ApiKey": "test-api-key"}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '93'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - python-requests/2.28.2
+    method: POST
+    uri: https://amsterdam-test.gisib.nl/api/api/Login
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/IvLr78wn
+        n0+LL4vvVLNvv7r6sji4nN2b3Xu+nP7g+eLh9U9dH1x/8fT43fMfHO88vzdvJ5+/+kH23Wk7+S59
+        9/pFNfnus59+/nu/qH6fN2e7L4qz5mz56v705OzTs7er3/snT77zcEwd/OR07yevJ4tn7U+9pi8W
+        z66y3/vF6vd5TY3f0u/fbcscn//0dO+LN1/svPjBk59+8fRZ8cVP/8T9Lz7/TvH7LH6q/GLv97n6
+        4rs/Of/i6Wzx4vPfZ++suCp+6veeX539dPXuxU9Pd168me59+eaL3ecn31lN732BwSy5j4IQmJy1
+        xcPpL/qJ3+v3uvcTv/f98mHxi45/n/u/98H+T158+tXp8fEPnjw7rg5++ru//9Pv/MT/Awh1g+8N
+        AQAA
+    headers:
+      Content-Encoding:
+      - gzip
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' blob: data: https:;img-src
+        ''self'' https: data: blob:;'
+      Content-Type:
+      - text/plain; charset=utf-8
+      Date:
+      - Wed, 01 Mar 2023 14:25:17 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - Bearer 1234567890
+      Connection:
+      - keep-alive
+      User-Agent:
+      - python-requests/2.28.2
+    method: GET
+    uri: https://amsterdam-test.gisib.nl/api/api/Collections/EPR%20Curatief/Items/3751039
+  response:
+    body:
+      string: '{"type":"FeatureCollection","crs":{"type":"name","properties":{"name":"urn:ogc:def:crs:EPSG::28992"}},"links":[{"rel":"next","type":"application/geo+json","title":"Next
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/EPR Curatief/items?crs=28992&limit=1&offset=1"},{"rel":"prev","type":"application/geo+json","title":"Previous
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/EPR Curatief/items?crs=28992&limit=1&offset=0"},{"rel":"first","type":"application/geo+json","title":"First
+        page","href":"https://amsterdam-test.gisib.nl/api/api/OGCCollections/EPR Curatief/items?crs=28992&limit=1&offset=0"}],"features":[{"type":"Feature","geometry":{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:28992"}},"coordinates":[127506.08,480104.53]},"properties":{"Boom":{"Id":1879642,"GUID":"{57F9DB47-BB54-4E41-9116-3CF4342F7F70}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Boom/items/1879642","Description":null},"SIG
+        Nummer melding":"1","Datum melding":"2023-01-27T14:18:00","Foto 1":null,"Foto
+        2":null,"Foto 3":null,"Omschrijving melding":null,"Registratie EPR":{"Id":3748950,"GUID":"{73BAB277-6DBF-4EC5-BE1D-3BC003A5A48E}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Registratie
+        EPR/items/3748950","Description":"f. EPR Bestreden"},"Inspectiedatum":null,"INSPECTEUR":null,"Inspecterende
+        organisatie":null,"Nesthoogte":null,"Niet bereikbaar met hoogwerker":false,"Niet
+        toegankelijk voor bestrijding":false,"Aantal nesten maat tennisbal":null,"Aantal
+        nesten maat voetbal":null,"Aantal nesten maat deken":null,"Prioriteit EPR":{"Id":3748925,"GUID":"{E4C7D646-D999-439F-953F-A89D31AB1ACC}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Prioriteit
+        EPR/items/3748925","Description":"Standaard (3 dagen)"},"Geplande uitvoeringsdatum
+        voor":null,"Opmerking algemeen":null,"Datum bestrijding":null,"Uitgevoerd
+        door":null,"Uitvoerende organisatie":null,"Bestrijdingsmethode EPR":null,"Bestrijding
+        uitvoering EPR":null,"Aantal nesten verwijderd maat tennisbal":null,"Aantal
+        nesten verwijderd maat voetbal":null,"Aantal nesten verwijderd maat deken":null,"Opmerking
+        uitvoerende organisatie":null,"Datum toezicht":"2023-02-08T17:16:24.484942","Toezichthouder":"Liu,
+        Jack","Acceptatie EPR":{"Id":3748944,"GUID":"{8F950C2D-AB2D-436C-8DB6-EC45FA4CA0AA}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Acceptatie
+        EPR/items/3748944","Description":"Goedgekeurd niet gezien"},"Aantal EPR nesten":null,"Nestformaat":{"Id":3749024,"GUID":"{5E1B42B8-E3BF-4C3E-9C27-CF09F8DE0C2A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Nestformaat/items/3749024","Description":"Nest
+        is zo groot als een tennisbal"},"Notitie toezichthouder":null,"Objecttype":{"Id":14109,"GUID":"{635136A6-334C-4C9A-B0AD-F69C0CDB52B7}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Objecttype/items/14109","Description":"Boom"},"Type":null,"Type
+        gedetailleerd":null,"Soortnaam":null,"Stamdiameter":null,"Openbare ruimte":null,"Buurt":{"Id":20565,"GUID":"{60ABA146-F6FE-4AA9-B3D6-C1A76D42DD4A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Buurt/items/20565","Description":"L-buurt"},"Wijk":{"Id":20366,"GUID":"{F4C68F4A-EAC5-4C8F-B596-4FF4F867DE4E}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Wijk/items/20366","Description":"Nellestein"},"Stadsdeel
+        of kern":{"Id":20268,"GUID":"{B52292B5-6FA0-427B-B4B8-BFFFBA08904B}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Stadsdeel
+        of kern/items/20268","Description":"Zuidoost"},"Woonplaats":{"Id":20249,"GUID":"{02CC5815-955D-4B4B-BB76-3E0E3B45280C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Woonplaats/items/20249","Description":"Amsterdam"},"Gemeente":{"Id":20247,"GUID":"{31C33111-C0B4-489E-8539-1B7D74DF2E5A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Gemeente/items/20247","Description":"Amsterdam"},"Beheergebied":{"Id":26976,"GUID":"{F8110411-9910-4FF0-9231-E12BE9DFD38D}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheergebied/items/26976","Description":"Gaasperdam,
+        Driemond"},"Meerstammig":false,"Aantal dagen open bestrijding":null,"Aantal
+        dagen resterend bestrijding":null,"Aantal dagen open inspectie":0,"Aantal
+        dagen resterend inspectie":2,"Start inspectiedatum":"2023-01-30T00:00:00","Uiterlijke
+        inspectiedatum":"2023-02-01T00:00:00","Foto bestrijding":null,"Code":null,"GUID":"{DDD9E8C2-39DB-4C57-99CB-0F45C5F3E009}","Id":3751039,"Description":null,"IMGeoId":null,"Valid_Till":null,"LastUpdate":"2023-01-28T17:16:24.484942","Revisie":2}},
+        {"type":"Feature","geometry":{"type":"Point","crs":{"type":"name","properties":{"name":"EPSG:28992"}},"coordinates":[127506.08,480104.53]},"properties":{"Boom":{"Id":1879642,"GUID":"{57F9DB47-BB54-4E41-9116-3CF4342F7F70}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Boom/items/1879642","Description":null},"SIG
+        Nummer melding":"1","Datum melding":"2023-01-27T14:18:00","Foto 1":null,"Foto
+        2":null,"Foto 3":null,"Omschrijving melding":null,"Registratie EPR":{"Id":3748950,"GUID":"{73BAB277-6DBF-4EC5-BE1D-3BC003A5A48E}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Registratie
+        EPR/items/3748950","Description":"f. EPR Bestreden"},"Inspectiedatum":null,"INSPECTEUR":null,"Inspecterende
+        organisatie":null,"Nesthoogte":null,"Niet bereikbaar met hoogwerker":false,"Niet
+        toegankelijk voor bestrijding":false,"Aantal nesten maat tennisbal":null,"Aantal
+        nesten maat voetbal":null,"Aantal nesten maat deken":null,"Prioriteit EPR":{"Id":3748925,"GUID":"{E4C7D646-D999-439F-953F-A89D31AB1ACC}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Prioriteit
+        EPR/items/3748925","Description":"Standaard (3 dagen)"},"Geplande uitvoeringsdatum
+        voor":null,"Opmerking algemeen":null,"Datum bestrijding":null,"Uitgevoerd
+        door":null,"Uitvoerende organisatie":null,"Bestrijdingsmethode EPR":null,"Bestrijding
+        uitvoering EPR":null,"Aantal nesten verwijderd maat tennisbal":null,"Aantal
+        nesten verwijderd maat voetbal":null,"Aantal nesten verwijderd maat deken":null,"Opmerking
+        uitvoerende organisatie":null,"Datum toezicht":"2023-02-08T17:16:24.484942","Toezichthouder":"Liu,
+        Jack","Acceptatie EPR":{"Id":3748944,"GUID":"{8F950C2D-AB2D-436C-8DB6-EC45FA4CA0AA}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Acceptatie
+        EPR/items/3748944","Description":"Goedgekeurd niet gezien"},"Aantal EPR nesten":null,"Nestformaat":{"Id":3749024,"GUID":"{5E1B42B8-E3BF-4C3E-9C27-CF09F8DE0C2A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Nestformaat/items/3749024","Description":"Nest
+        is zo groot als een tennisbal"},"Notitie toezichthouder":null,"Objecttype":{"Id":14109,"GUID":"{635136A6-334C-4C9A-B0AD-F69C0CDB52B7}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Objecttype/items/14109","Description":"Boom"},"Type":null,"Type
+        gedetailleerd":null,"Soortnaam":null,"Stamdiameter":null,"Openbare ruimte":null,"Buurt":{"Id":20565,"GUID":"{60ABA146-F6FE-4AA9-B3D6-C1A76D42DD4A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Buurt/items/20565","Description":"L-buurt"},"Wijk":{"Id":20366,"GUID":"{F4C68F4A-EAC5-4C8F-B596-4FF4F867DE4E}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Wijk/items/20366","Description":"Nellestein"},"Stadsdeel
+        of kern":{"Id":20268,"GUID":"{B52292B5-6FA0-427B-B4B8-BFFFBA08904B}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Stadsdeel
+        of kern/items/20268","Description":"Zuidoost"},"Woonplaats":{"Id":20249,"GUID":"{02CC5815-955D-4B4B-BB76-3E0E3B45280C}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Woonplaats/items/20249","Description":"Amsterdam"},"Gemeente":{"Id":20247,"GUID":"{31C33111-C0B4-489E-8539-1B7D74DF2E5A}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Gemeente/items/20247","Description":"Amsterdam"},"Beheergebied":{"Id":26976,"GUID":"{F8110411-9910-4FF0-9231-E12BE9DFD38D}","Url":"https://amsterdam-test.gisib.nl/api/api/Collections/Beheergebied/items/26976","Description":"Gaasperdam,
+        Driemond"},"Meerstammig":false,"Aantal dagen open bestrijding":null,"Aantal
+        dagen resterend bestrijding":null,"Aantal dagen open inspectie":0,"Aantal
+        dagen resterend inspectie":2,"Start inspectiedatum":"2023-01-30T00:00:00","Uiterlijke
+        inspectiedatum":"2023-02-01T00:00:00","Foto bestrijding":null,"Code":null,"GUID":"{DDD9E8C2-39DB-4C57-99CB-0F45C5F3E009}","Id":3751039,"Description":null,"IMGeoId":null,"Valid_Till":null,"LastUpdate":"2023-01-28T17:16:24.484942","Revisie":2}}]}'
+    headers:
+      Content-Length:
+      - '4574'
+      Content-Security-Policy:
+      - 'default-src ''self'' ''unsafe-inline'' ''unsafe-eval'' blob: data: https:;img-src
+        ''self'' https: data: blob:;'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Wed, 01 Mar 2023 14:25:17 GMT
+      Expect-CT:
+      - enforce, max-age=43200
+      Permissions-Policy:
+      - vibrate=(self)
+      Referrer-Policy:
+      - no-referrer-when-downgrade
+      Strict-Transport-Security:
+      - max-age=31536000; includeSubDomains; preload
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/app/signals_gisib/tests/gisib/test_api.py
+++ b/app/signals_gisib/tests/gisib/test_api.py
@@ -1,3 +1,4 @@
+from django.core.exceptions import MultipleObjectsReturned, ObjectDoesNotExist
 from django.test import TestCase, override_settings
 from django.utils import timezone
 from freezegun import freeze_time
@@ -53,6 +54,16 @@ class GISIBApiTestCase(TestCase):
     def test_get_collection(self):
         result = get_collection('Boom', 1879642)
         self.assertEqual(result['properties']['Id'], 1879642)
+
+    @gisib_api_vcr.use_cassette()
+    def test_get_collection_raises_object_does_not_exist(self):
+        with self.assertRaises(ObjectDoesNotExist):
+            get_collection('Boom', 1879642)
+
+    @gisib_api_vcr.use_cassette()
+    def test_get_collection_raises_multiple_objects_returned(self):
+        with self.assertRaises(MultipleObjectsReturned):
+            get_collection('Boom', 1879642)
 
     @gisib_api_vcr.use_cassette()
     def test_post_collection_insert(self):

--- a/app/signals_gisib/tests/gisib/test_update_epr_curative.py
+++ b/app/signals_gisib/tests/gisib/test_update_epr_curative.py
@@ -84,3 +84,43 @@ class UpdateEPRCurativeTestCase(TransactionTestCase):
         updated_signal, updated = update_epr_curatives_for_signal(signal)
         self.assertEqual(signal.signal_id, updated_signal.signal_id)
         self.assertFalse(updated)
+
+    @gisib_api_vcr.use_cassette()
+    def test_update_epr_curative_collection_item_does_not_exist(self):
+        tree = CollectionItemFactory.create(object_kind_name='Boom', gisib_id=1879642,
+                                            properties={'species': 'Quercus'})
+        signal_extra_properties = [{'id': 'extra_eikenprocessierups',
+                                    'answer': [{'id': tree.gisib_id,
+                                                'type': 'Eikenboom'}, ]},
+                                   {'id': 'extra_nest_grootte',
+                                    'label': 'Op de boom gezien',
+                                    'answer': {'id': 'deken',
+                                               'label': 'Rupsen bedekken de stam als een deken'}}]
+        yesterday = timezone.now() - timedelta(weeks=1)
+        collection_item = CollectionItemFactory.create(object_kind_name='EPR Curatief', gisib_id=3751039,
+                                                       raw_properties={'LastUpdate': yesterday.isoformat()})
+        epr_curative = EPRCurativeFactory.create(signal__signal_extra_properties=signal_extra_properties,
+                                                 collection_item=collection_item, gisib_id=3751039)
+
+        _, updated = update_epr_curatives_for_signal(epr_curative.signal)
+        self.assertFalse(updated)
+
+    @gisib_api_vcr.use_cassette()
+    def test_update_epr_curative_collection_item_multiple_objects_returned(self):
+        tree = CollectionItemFactory.create(object_kind_name='Boom', gisib_id=1879642,
+                                            properties={'species': 'Quercus'})
+        signal_extra_properties = [{'id': 'extra_eikenprocessierups',
+                                    'answer': [{'id': tree.gisib_id,
+                                                'type': 'Eikenboom'}, ]},
+                                   {'id': 'extra_nest_grootte',
+                                    'label': 'Op de boom gezien',
+                                    'answer': {'id': 'deken',
+                                               'label': 'Rupsen bedekken de stam als een deken'}}]
+        yesterday = timezone.now() - timedelta(weeks=1)
+        collection_item = CollectionItemFactory.create(object_kind_name='EPR Curatief', gisib_id=3751039,
+                                                       raw_properties={'LastUpdate': yesterday.isoformat()})
+        epr_curative = EPRCurativeFactory.create(signal__signal_extra_properties=signal_extra_properties,
+                                                 collection_item=collection_item, gisib_id=3751039)
+
+        _, updated = update_epr_curatives_for_signal(epr_curative.signal)
+        self.assertFalse(updated)


### PR DESCRIPTION
## Description

The GISIB API get_collection function retrieves one item from the GISIB system. However it is possible that the retrieved item does not exist and therefore returns a feature collection with an empty list. Also added the option to detect if multiple features where returned. These cases will raise the Django core `ObjectDoesNotExist` and `MultipleObjectsReturned` exceptions.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary