### PR TITLE
Increased the gisib_id range in the CollectionItemFactory

### DIFF
--- a/app/signals_gisib/tests/factories.py
+++ b/app/signals_gisib/tests/factories.py
@@ -15,7 +15,7 @@ class CollectionItemFactory(DjangoModelFactory):
         model = CollectionItem
         django_get_or_create = ('gisib_id', )
 
-    gisib_id = Faker('random_int', min=1000, max=9999, step=1)
+    gisib_id = Faker('random_int', min=1, max=99999, step=1)
     object_kind_name = FuzzyChoice(['Boom', ])
     geometry = FuzzyPoint(*BBOX_AMSTERDAM)
     properties = {}


### PR DESCRIPTION
## Description

Increased the gisib_id range in the CollectionItemFactory

## Motivation

The gisib_id range was set between 1000 and 9999, this caused duplicate gisib_id's to be generated by the CollectionItemFactory and therefore returing already created CollectionItems. This caused tests to fail because, for example, 20 items where expected but only 19 where created.

This is not a real fix and it could still happen that a duplicate id is generated however the changes of that have declined with these new settings.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary
