### PR TITLE
Fixed GISIB_SLEEP to actually check the GISIB_SLEEP env var instead of GISIB_LIMIT

### DIFF
--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -185,7 +185,7 @@ GISIB_USERNAME = os.getenv('GISIB_USERNAME')
 GISIB_PASSWORD = os.getenv('GISIB_PASSWORD')
 GISIB_APIKEY = os.getenv('GISIB_APIKEY')
 GISIB_LIMIT = os.getenv('GISIB_LIMIT', 500)
-GISIB_SLEEP = os.getenv('GISIB_LIMIT', 0.5)  # seconds to sleep between consecutive calls
+GISIB_SLEEP = os.getenv('GISIB_SLEEP', 0.5)  # seconds to sleep between consecutive calls
 GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES = ['a. Melding', 'b. Inspectie', 'c. Registratie EPR',
                                                 'g. EPR Deels bestreden']
 GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES = ['d. Geen', 'e. EPR Niet bestrijden', 'f. EPR Bestreden',


### PR DESCRIPTION
## Description

Fixed GISIB_SLEEP to actually check the GISIB_SLEEP env var instead of GISIB_LIMIT

## Checklist
- [X] I have tested these changes thoroughly
- [ ] I have updated the relevant documentation, if necessary
- [ ] I have added/updated tests, if necessary
- [ ] I have followed the project's coding style and guidelines
- [ ] I have added/updated the changelog, if necessary