### PR TITLE
Fixing settings GISIB_SLEEP and GISIB_LIMIT, added setting REST_FRAMEWORK_PAGE_SIZE

### DIFF
--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -162,7 +162,7 @@ if DEBUG:
 # Rest Framework
 REST_FRAMEWORK = {
     'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
-    'PAGE_SIZE': 100,
+    'PAGE_SIZE': int(os.getenv('REST_FRAMEWORK_PAGE_SIZE', '100')),
     'DEFAULT_FILTER_BACKENDS': (
         'django_filters.rest_framework.DjangoFilterBackend',
     ),
@@ -193,8 +193,8 @@ GISIB_BASE_URI = os.getenv('GISIB_BASE_URI')
 GISIB_USERNAME = os.getenv('GISIB_USERNAME')
 GISIB_PASSWORD = os.getenv('GISIB_PASSWORD')
 GISIB_APIKEY = os.getenv('GISIB_APIKEY')
-GISIB_LIMIT = os.getenv('GISIB_LIMIT', 500)
-GISIB_SLEEP = os.getenv('GISIB_SLEEP', 0.5)  # seconds to sleep between consecutive calls
+GISIB_LIMIT = int(os.getenv('GISIB_LIMIT', '500'))
+GISIB_SLEEP = float(os.getenv('GISIB_SLEEP', '0.5'))  # seconds to sleep between consecutive calls
 GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES = ['a. Melding', 'b. Inspectie', 'c. Registratie EPR',
                                                 'g. EPR Deels bestreden']
 GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES = ['d. Geen', 'e. EPR Niet bestrijden', 'f. EPR Bestreden',


### PR DESCRIPTION
## Description

`os.getenv` returns values as a string. However `GISIB_SLEEP` needed to be a float and `GISIB_LIMIT` an integer. This commit fixes this. It also adds the `REST_FRAMEWORK_PAGE_SIZE` env variable so that we can easily make changes to the default behaviour.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary
