### PR TITLE
Use docker compose to run tox instead of setting up an environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,42 +6,20 @@ jobs:
     name: Unit tests, Flake8 and Isort
     runs-on: ubuntu-latest
 
-    services:
-      database:
-        image: postgis/postgis:15-3.3
-        env:
-          POSTGRES_DB: signals-gisib
-          POSTGRES_USER: signals-gisib
-          POSTGRES_PASSWORD: insecure
-
-        ports: ['54321:5432']
-        options: --health-cmd pg_isready --health-interval 10s --health-timeout 5s --health-retries 5
+    strategy:
+      matrix:
+        compose-version: [ 1.0.32 ]
 
     steps:
       - uses: actions/checkout@v3
 
-      - name: Setup Python 3.11
-        uses: actions/setup-python@v4
-        with:
-          python-version: "3.11"
-
-      - name: Install geospatial libraries # https://docs.djangoproject.com/en/4.1/ref/contrib/gis/install/geolibs/
-        run: sudo apt update && sudo apt install binutils libproj-dev gdal-bin
-
-      - name: Install dependencies
+      - name: Set up Docker Compose
         run: |
-          python -m pip install --upgrade pip
-          pip install --use-pep517 -r requirements_test.txt
+          curl -L https://raw.githubusercontent.com/docker/compose-cli/v${{ matrix.compose-version }}/scripts/install/install_linux.sh | sh
+        shell: bash
+
+      - name: Build Docker images
+        run: docker-compose build
 
       - name: Run tests
-        env:
-          DATABASE_HOST: localhost
-        run: |
-          cd app/
-          tox
-
-      - name: Upload coverage report
-        uses: actions/upload-artifact@v3
-        with:
-          name: coverage-report
-          path: /tmp/test/htmlcov/
+        run: docker-compose run app tox


### PR DESCRIPTION
## Description

Use docker compose to run tox instead of setting up an environment

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary
