### PR TITLE
Fixed the SignalAdmin

### DIFF
--- a/app/signals_gisib/admin.py
+++ b/app/signals_gisib/admin.py
@@ -75,11 +75,11 @@ class SignalAdmin(SimpleHistoryAdmin):
 
     @admin.display(description='Processed count')
     def get_epr_curative_not_processed_count(self, obj):
-        return obj.epr_curative.exclude(processed_at__isnull=True).count()
+        return obj.epr_curative.exclude(processed=False).count()
 
     @admin.display(description='Not processed count')
     def get_epr_curative_processed_count(self, obj):
-        return obj.epr_curative.exclude(processed_at__isnull=False).count()
+        return obj.epr_curative.exclude(processed=True).count()
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
## Description

Fixed the `SignalAdmin`, the admin was checking if there where (un)processed epr_curative(s). However the `epr_curative` has a `processed` boolean instead of a `processed_at` datetime.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary
