### PR TITLE
Fixed an issue with the processed_at of a Signal

### DIFF
--- a/app/signals_gisib/gisib/epr_curative_status.py
+++ b/app/signals_gisib/gisib/epr_curative_status.py
@@ -1,7 +1,6 @@
 from typing import List
 
 from django.conf import settings
-from django.utils import timezone
 
 from signals_gisib.gisib.update_epr_curative import update_epr_curatives_for_signal
 from signals_gisib.models import CollectionItem, Signal
@@ -45,8 +44,3 @@ def check_status(signal: Signal):
                 epr_curative.processed = _epr_registration_status['Id'] in __epr_processed_status_list
 
             epr_curative.save()
-
-    if not unprocessed_qs.exists():
-        # All EPR Curative have been processed, the Signal has been processed.
-        signal.processed_at = timezone.now()
-        signal.save()

--- a/app/signals_gisib/tests/gisib/test_epr_curative_status.py
+++ b/app/signals_gisib/tests/gisib/test_epr_curative_status.py
@@ -90,4 +90,3 @@ class EPRCurativeStatusTestCase(TransactionTestCase):
         check_status(signal=test_signal)
 
         test_signal.refresh_from_db()
-        self.assertIsNotNone(test_signal.processed_at)


### PR DESCRIPTION
## Description

Fixed an issue with the processed_at of a Signal, it was set to early in the process, therefore a Signal was never set to "done external" in Signalen.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary

