### PR TITLE
Made the settings GISIB epr statusses configurable through ENV variables

### DIFF
--- a/app/main/settings.py
+++ b/app/main/settings.py
@@ -195,10 +195,14 @@ GISIB_PASSWORD = os.getenv('GISIB_PASSWORD')
 GISIB_APIKEY = os.getenv('GISIB_APIKEY')
 GISIB_LIMIT = int(os.getenv('GISIB_LIMIT', '500'))
 GISIB_SLEEP = float(os.getenv('GISIB_SLEEP', '0.5'))  # seconds to sleep between consecutive calls
-GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES = ['a. Melding', 'b. Inspectie', 'c. Registratie EPR',
-                                                'g. EPR Deels bestreden']
-GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES = ['d. Geen', 'e. EPR Niet bestrijden', 'f. EPR Bestreden',
-                                            'h. Dubbele melding', 'i. Niet in beheergebied']
+GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES = os.getenv(
+    'GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES',
+    'a. Melding,b. Inspectie,c. Registratie EPR,g. EPR Deels bestreden'
+).split(',')
+GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES = os.getenv(
+    'GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES',
+    'd. Geen,e. EPR Niet bestrijden,f. EPR Bestreden,h. Dubbele melding,i. Niet in beheergebied'
+).split(',')
 GISIB_REGISTRATIE_EPR_STATUSES = GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES + GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES
 
 


### PR DESCRIPTION
## Description

Made the settings GISIB_REGISTRATIE_EPR_NOT_PROCESSED_STATUSES and GISIB_REGISTRATIE_EPR_PROCESSED_STATUSES configurable through ENV variables. The defaults remain the same.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary
