### PR TITLE
There was an FE change that is now providing id's as empty strings wh…

### DIFF
--- a/app/signals_gisib/gisib/create_epr_curative.py
+++ b/app/signals_gisib/gisib/create_epr_curative.py
@@ -23,7 +23,7 @@ def _get_tree_ids(extra_properties: List[dict]) -> List[int]:
         if extra_property['id'] == 'extra_eikenprocessierups':
             answers = extra_property.get('answer', [])
             for answer in answers:
-                if 'id' in answer and _tree_exists(answer['id']):
+                if 'id' in answer and answer['id'] and _tree_exists(answer['id']):
                     tree_ids.append(answer['id'])
                 else:
                     tree_ids.append(None)


### PR DESCRIPTION
## Issue(s) addressed

There was an FE change that is now providing id's as empty strings when the option "not on map" has been selected.

This resulted in an error when querying on a specific tree that was expecting a number instead of an empty string. Adding an additional check if the given "id" is also set eliminates this problem.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary

