### PR TITLE
No longer use a function for the `object_kind_name` filter, instead use a simple list as it was causing issues with drf-yasg

### DIFF
--- a/app/signals_gisib/filters.py
+++ b/app/signals_gisib/filters.py
@@ -1,29 +1,13 @@
-from typing import List
-
 from django.contrib.gis.geos import Polygon
 from django.db.models import Q, QuerySet
 from django_filters import ChoiceFilter, FilterSet, NumberFilter
 from django_filters.rest_framework import CharFilter
 from rest_framework.exceptions import ValidationError
 
-from signals_gisib.models import CollectionItem
-
-
-def _object_kind_name_choices() -> List:
-    return [
-        (object_kind_name, f'{object_kind_name}')
-        for object_kind_name in CollectionItem.objects.filter(
-            geometry__isnull=False
-        ).values_list(
-            'object_kind_name',
-            flat=True
-        ).distinct()
-    ]
-
 
 class FeatureCollectionFilterSet(FilterSet):
     id = NumberFilter(field_name='gisib_id', lookup_expr='exact')
-    object_kind_name = ChoiceFilter(lookup_expr='iexact', required=True, choices=_object_kind_name_choices)
+    object_kind_name = ChoiceFilter(lookup_expr='iexact', required=True, choices=[('Boom', 'Boom')])
     bbox = CharFilter(method='filter_by_bbox')
 
     def filter_by_bbox(self, queryset: QuerySet, name: str, value: str) -> QuerySet:

--- a/app/signals_gisib/tests/gisib/test_geography_endpoint.py
+++ b/app/signals_gisib/tests/gisib/test_geography_endpoint.py
@@ -6,10 +6,7 @@ from signals_gisib.tests.utils import BBOX_AMSTERDAM
 
 class GeographyEndpointTestCase(APITestCase):
     def setUp(self):
-        CollectionItemFactory.create_batch(20, object_kind_name='object_kind_1')
-        CollectionItemFactory.create_batch(5, object_kind_name='object_kind_2')
-        CollectionItemFactory.create_batch(5, object_kind_name='object_kind_3')
-        CollectionItemFactory.create_batch(5, object_kind_name='object_kind_4')
+        CollectionItemFactory.create_batch(20, object_kind_name='Boom')
 
     def test_list_geography_filter_object_kind_name_required(self):
         response = self.client.get('/public/gisib/geography/')
@@ -17,7 +14,7 @@ class GeographyEndpointTestCase(APITestCase):
 
     def test_list_geography_paginated(self):
         for page in range(1, 5):
-            response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'object_kind_1',
+            response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'Boom',
                                                                          'page_size': 5, 'page': page})
 
             self.assertEqual(response.status_code, 200)
@@ -25,18 +22,11 @@ class GeographyEndpointTestCase(APITestCase):
             self.assertEqual(len(response.data['features']), 5)
 
     def test_list_geography_paginated_invalid_page(self):
-        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'object_kind_1', 'page': 999})
+        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'Boom', 'page': 999})
         self.assertEqual(response.status_code, 404)
 
-    def test_list_geography_filtered_by_object_kind_name(self):
-        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'object_kind_2'})
-
-        self.assertEqual(response.status_code, 200)
-        self.assertEqual(response.data['type'], 'FeatureCollection')
-        self.assertEqual(len(response.data['features']), 5)
-
     def test_list_geography_filtered_by_bbox(self):
-        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'object_kind_1',
+        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'Boom',
                                                                      'bbox': ','.join(str(x) for x in BBOX_AMSTERDAM)})
 
         self.assertEqual(response.status_code, 200)
@@ -44,12 +34,12 @@ class GeographyEndpointTestCase(APITestCase):
         self.assertEqual(len(response.data['features']), 20)
 
     def test_list_geography_filtered_by_invalid_bbox(self):
-        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'object_kind_1',
+        response = self.client.get('/public/gisib/geography/', data={'object_kind_name': 'Boom',
                                                                      'bbox': 'invalid,invalid,invalid,invalid'})
         self.assertEqual(response.status_code, 400)
 
         response = self.client.get('/public/gisib/geography/',
-                                   data={'object_kind_name': 'object_kind_1',
+                                   data={'object_kind_name': 'Boom',
                                          'bbox': f'{",".join(str(x) for x in BBOX_AMSTERDAM)},1.234567890'})
         self.assertEqual(response.status_code, 400)
 


### PR DESCRIPTION
## Description

This PR updates the `object_kind_name` choices in the `FeatureCollectionFilterSet` to be a simple list that only contains the "Boom" option. This change resolves the issue with drf-yasg and aligns with our project's current usage, as we have no plans to implement additional functionality at this moment.

## Checklist
- [X] I have tested these changes thoroughly
- [X] I have updated the relevant documentation, if necessary
- [X] I have added/updated tests, if necessary
- [X] I have followed the project's coding style and guidelines
- [X] I have added/updated the changelog, if necessary
